### PR TITLE
Improve Icecast mount handling diagnostics

### DIFF
--- a/shaqcast/README.md
+++ b/shaqcast/README.md
@@ -4,3 +4,7 @@ Minimal GUI tool (wxPython) that listens to a selected Windows output device (lo
 
 - Shoutcast (one or more SIDs)
 - Icecast (one or more mountpoints)
+
+For Icecast, enter multiple mountpoints separated by commas, semicolons, or new lines,
+for example `/stream,/stream2`. Use the Icecast user that is allowed to call
+`/admin/metadata`; on some servers this is `admin`, not `source`.

--- a/shaqcast/shaqcast/config_store.py
+++ b/shaqcast/shaqcast/config_store.py
@@ -28,7 +28,7 @@ def config_path() -> Path:
 def load_config() -> dict[str, Any]:
     path = config_path()
     try:
-        raw = path.read_text(encoding="utf-8")
+        raw = path.read_text(encoding="utf-8-sig")
     except OSError:
         return {}
     try:

--- a/shaqcast/shaqcast/gui.py
+++ b/shaqcast/shaqcast/gui.py
@@ -10,6 +10,7 @@ import wx
 
 from .audio import default_microphone_id, default_speaker_id, list_microphones, list_speakers
 from .config_store import config_version, decrypt_secret, encrypt_secret, load_config, save_config
+from .icecast import parse_mounts
 from .i18n import I18n, UI_LANGUAGE_CHOICES, ui_language_from_config
 from .shazam_regions import (
     SUPPORTED_ENDPOINT_COUNTRIES,
@@ -688,14 +689,7 @@ class MainFrame(wx.Frame):
         self._persist_config()
 
     def _parse_icecast_mounts(self) -> list[str]:
-        raw = self._icecast_mounts.GetValue().strip()
-        parts = [p.strip() for p in raw.split(",") if p.strip()]
-        mounts: list[str] = []
-        for part in parts:
-            mount = part
-            if not mount.startswith("/"):
-                mount = "/" + mount
-            mounts.append(mount)
+        mounts = parse_mounts(self._icecast_mounts.GetValue())
         if not mounts:
             raise ValueError(self._t("error.no_mounts"))
         return mounts

--- a/shaqcast/shaqcast/icecast.py
+++ b/shaqcast/shaqcast/icecast.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import base64
+import re
 from dataclasses import dataclass
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
+
+_MOUNT_SEPARATOR_RE = re.compile(r"[,;\r\n]+")
 
 
 @dataclass(frozen=True, slots=True)
@@ -28,6 +31,22 @@ def _looks_successful(status: int | None, body: str) -> bool:
     return True
 
 
+def parse_mounts(raw: str) -> list[str]:
+    mounts: list[str] = []
+    seen: set[str] = set()
+    for part in _MOUNT_SEPARATOR_RE.split(raw or ""):
+        mount = part.strip()
+        if not mount:
+            continue
+        if not mount.startswith("/"):
+            mount = "/" + mount
+        if mount in seen:
+            continue
+        mounts.append(mount)
+        seen.add(mount)
+    return mounts
+
+
 def update_now_playing(
     *,
     host: str,
@@ -46,9 +65,8 @@ def update_now_playing(
     with HTTP Basic auth (username/password).
     """
     username = (username or "source").strip() or "source"
-    mount = (mount or "").strip()
-    if mount and not mount.startswith("/"):
-        mount = "/" + mount
+    mounts = parse_mounts(mount)
+    mount = mounts[0] if mounts else ""
 
     base_url = f"http://{host}:{port}/admin/metadata"
     query = urlencode(

--- a/shaqcast/shaqcast/streamer.py
+++ b/shaqcast/shaqcast/streamer.py
@@ -36,6 +36,24 @@ _MIN_REQUEST_INTERVAL_S = max(0.0, min(60.0, _MIN_REQUEST_INTERVAL_S))
 StreamServerType = Literal["shoutcast", "icecast"]
 
 
+def _compact_response_body(body: str, *, limit: int = 180) -> str:
+    text = " ".join((body or "").split())
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3] + "..."
+
+
+def _update_failed_log(prefix: str, result: object) -> str:
+    status = getattr(result, "status", None)
+    status_text = status if status is not None else "n/a"
+    method = getattr(result, "method", "unknown")
+    message = f"{prefix} update failed ({method}, status={status_text})"
+    body = _compact_response_body(str(getattr(result, "body", "") or ""))
+    if body:
+        message = f"{message}: {body}"
+    return message
+
+
 @dataclass(frozen=True, slots=True)
 class StreamSettings:
     host: str
@@ -348,10 +366,7 @@ class StreamingSession:
                         if result.ok:
                             self._log(f"[mount {mount}] updated ({result.method})")
                         else:
-                            status = result.status if result.status is not None else "n/a"
-                            self._log(
-                                f"[mount {mount}] update failed ({result.method}, status={status})"
-                            )
+                            self._log(_update_failed_log(f"[mount {mount}]", result))
                 else:
                     for sid in self._settings.sids:
                         result = update_shoutcast_now_playing(
@@ -364,10 +379,7 @@ class StreamingSession:
                         if result.ok:
                             self._log(f"[sid {sid}] updated ({result.method})")
                         else:
-                            status = result.status if result.status is not None else "n/a"
-                            self._log(
-                                f"[sid {sid}] update failed ({result.method}, status={status})"
-                            )
+                            self._log(_update_failed_log(f"[sid {sid}]", result))
 
                 self._last_track_sent = fallback
                 continue
@@ -392,8 +404,7 @@ class StreamingSession:
                     if result.ok:
                         self._log(f"[mount {mount}] updated ({result.method})")
                     else:
-                        status = result.status if result.status is not None else "n/a"
-                        self._log(f"[mount {mount}] update failed ({result.method}, status={status})")
+                        self._log(_update_failed_log(f"[mount {mount}]", result))
             else:
                 for sid in self._settings.sids:
                     result = update_shoutcast_now_playing(
@@ -406,7 +417,6 @@ class StreamingSession:
                     if result.ok:
                         self._log(f"[sid {sid}] updated ({result.method})")
                     else:
-                        status = result.status if result.status is not None else "n/a"
-                        self._log(f"[sid {sid}] update failed ({result.method}, status={status})")
+                        self._log(_update_failed_log(f"[sid {sid}]", result))
 
             self._last_track_sent = now_playing

--- a/shaqcast/tests/test_config_store.py
+++ b/shaqcast/tests/test_config_store.py
@@ -22,6 +22,16 @@ def test_config_roundtrip(monkeypatch, tmp_path) -> None:
     assert config_path().name == "config.json"
 
 
+def test_config_loads_utf8_bom(monkeypatch, tmp_path) -> None:
+    _set_test_config_dir(monkeypatch, tmp_path)
+
+    path = config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('\ufeff{"title": "Zażółć gęślą jaźń"}', encoding="utf-8")
+
+    assert load_config() == {"title": "Zażółć gęślą jaźń"}
+
+
 def test_encrypt_decrypt_secret_roundtrip() -> None:
     secret = "p@ssw0rd!"
     token = encrypt_secret(secret)

--- a/shaqcast/tests/test_icecast.py
+++ b/shaqcast/tests/test_icecast.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from shaqcast.icecast import _looks_successful
+from shaqcast.icecast import _looks_successful, parse_mounts
 
 
 def test_looks_successful_basic() -> None:
@@ -13,3 +13,15 @@ def test_looks_successful_rejects_errors() -> None:
     assert _looks_successful(401, "OK") is False
     assert _looks_successful(200, "Invalid password") is False
     assert _looks_successful(200, "ERROR something") is False
+
+
+def test_parse_mounts_accepts_common_separators() -> None:
+    assert parse_mounts("/elradio, elradio_raw\n/backup;backup") == [
+        "/elradio",
+        "/elradio_raw",
+        "/backup",
+    ]
+
+
+def test_parse_mounts_deduplicates() -> None:
+    assert parse_mounts("stream, /stream, stream2") == ["/stream", "/stream2"]


### PR DESCRIPTION
## Summary

This PR improves the Icecast path in shaqcast based on real-world multi-mountpoint usage.

Changes:
- allow Icecast mountpoints to be separated by commas, semicolons, or new lines
- normalize mountpoints with a leading slash and remove duplicates while preserving order
- include a compact response body in failed metadata update logs, so errors like unauthorized or missing mountpoint are easier to diagnose
- load config.json with UTF-8 BOM tolerance while still saving plain UTF-8 JSON
- document Icecast multi-mountpoint usage and the need to use a user allowed to call /admin/metadata

## Tests

- `python -m pytest tests` from the `shaqcast` directory
- Result: 16 passed