### PR TITLE
Add Shaqcast Windows autostart option

### DIFF
--- a/shaqcast/shaqcast/gui.py
+++ b/shaqcast/shaqcast/gui.py
@@ -21,6 +21,12 @@ from .shazam_regions import (
     language_choice_strings,
     language_codes,
 )
+from .startup import (
+    AutostartError,
+    is_autostart_enabled,
+    is_autostart_supported,
+    set_autostart_enabled,
+)
 from .streamer import StreamSettings, StreamingSession
 
 _SYGNALISTA_GUI_IMPORT_ERROR: str | None = None
@@ -38,6 +44,22 @@ _STRINGS: dict[str, dict[str, str]] = {
     "tooltip.ui_language": {
         "pl": "Zmień język interfejsu (wymaga restartu aplikacji).",
         "en": "Change the interface language (requires app restart).",
+    },
+    "label.start_with_windows": {
+        "pl": "Uruchamiaj Shaqcast z systemem",
+        "en": "Start Shaqcast with Windows",
+    },
+    "name.start_with_windows": {
+        "pl": "Uruchamiaj Shaqcast z systemem",
+        "en": "Start Shaqcast with Windows",
+    },
+    "tooltip.start_with_windows": {
+        "pl": "Dodaje lub usuwa skrót Shaqcasta w folderze Autostart bieżącego użytkownika.",
+        "en": "Adds or removes a Shaqcast shortcut in the current user's Startup folder.",
+    },
+    "tooltip.start_with_windows_unsupported": {
+        "pl": "Autostart jest dostępny tylko w Windows.",
+        "en": "Autostart is only available on Windows.",
     },
     "info.restart_required": {
         "pl": "Zapisano język. Uruchom ponownie aplikację, aby zastosować zmianę.",
@@ -178,6 +200,12 @@ _STRINGS: dict[str, dict[str, str]] = {
     },
     "log.listening_started": {"pl": "Nasłuch uruchomiony.", "en": "Listening started."},
     "log.listening_stopped": {"pl": "Nasłuch zatrzymany.", "en": "Listening stopped."},
+    "log.autostart_enabled": {"pl": "Autostart włączony.", "en": "Autostart enabled."},
+    "log.autostart_disabled": {"pl": "Autostart wyłączony.", "en": "Autostart disabled."},
+    "log.autostart_failed": {
+        "pl": "Nie udało się zmienić autostartu: {error}",
+        "en": "Failed to change autostart: {error}",
+    },
 }
 
 try:
@@ -435,6 +463,23 @@ class MainFrame(wx.Frame):
         self._ui_language_choice.SetSelection(0 if ui_language == "pl" else 1)
         self._ui_language_choice.Bind(wx.EVT_CHOICE, self._on_ui_language_changed)
 
+        start_with_windows = bool(config.get("start_with_windows"))
+        self._autostart_supported = is_autostart_supported()
+        if self._autostart_supported:
+            try:
+                start_with_windows = is_autostart_enabled()
+            except Exception:
+                pass
+
+        self._start_with_windows = wx.CheckBox(panel, label=t("label.start_with_windows"))
+        _a11y(self._start_with_windows, t("name.start_with_windows"))
+        self._start_with_windows.SetValue(start_with_windows)
+        if self._autostart_supported:
+            self._start_with_windows.SetToolTip(t("tooltip.start_with_windows"))
+        else:
+            self._start_with_windows.Disable()
+            self._start_with_windows.SetToolTip(t("tooltip.start_with_windows_unsupported"))
+
         preset_label = wx.StaticText(panel, label=t("label.preset"))
         self._preset = wx.Choice(panel)
         _a11y(self._preset, t("label.preset").rstrip(":"))
@@ -551,6 +596,9 @@ class MainFrame(wx.Frame):
         grid.Add(ui_lang_label, 0, wx.ALIGN_CENTER_VERTICAL)
         grid.Add(self._ui_language_choice, 1, wx.EXPAND)
 
+        grid.AddSpacer(0)
+        grid.Add(self._start_with_windows, 1, wx.EXPAND)
+
         grid.Add(host_label, 0, wx.ALIGN_CENTER_VERTICAL)
         grid.Add(self._host, 1, wx.EXPAND)
 
@@ -615,6 +663,7 @@ class MainFrame(wx.Frame):
         self._refresh.Bind(wx.EVT_BUTTON, self._on_refresh)
         self._advanced_btn.Bind(wx.EVT_BUTTON, self._on_advanced)
         self._report_btn.Bind(wx.EVT_BUTTON, self._on_report_issue)
+        self._start_with_windows.Bind(wx.EVT_CHECKBOX, self._on_start_with_windows_changed)
         self._start.Bind(wx.EVT_BUTTON, self._on_start)
         self._stop.Bind(wx.EVT_BUTTON, self._on_stop)
         self._source.Bind(wx.EVT_CHOICE, self._on_source_changed)
@@ -805,6 +854,7 @@ class MainFrame(wx.Frame):
         return {
             "version": config_version(),
             "ui_language": ui_language,
+            "start_with_windows": bool(self._start_with_windows.GetValue()),
             "server_type": self._server_type_value(),
             "host": self._host.GetValue().strip(),
             "port": port_val,
@@ -908,6 +958,20 @@ class MainFrame(wx.Frame):
             _APP_NAME,
             wx.OK | wx.ICON_INFORMATION,
             self,
+        )
+
+    def _on_start_with_windows_changed(self, _evt: wx.CommandEvent) -> None:
+        enabled = bool(self._start_with_windows.GetValue())
+        try:
+            set_autostart_enabled(enabled)
+        except (AutostartError, OSError) as exc:
+            self._start_with_windows.SetValue(not enabled)
+            self.log(self._t("log.autostart_failed", error=str(exc)))
+            return
+
+        self._persist_config()
+        self.log(
+            self._t("log.autostart_enabled" if enabled else "log.autostart_disabled")
         )
 
     def _on_device_changed(self, _evt: wx.CommandEvent) -> None:

--- a/shaqcast/shaqcast/startup.py
+++ b/shaqcast/shaqcast/startup.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+_APP_SHORTCUT_NAME = "Shaqcast.lnk"
+
+
+class AutostartError(RuntimeError):
+    """Raised when Windows autostart cannot be changed."""
+
+
+@dataclass(frozen=True)
+class ShortcutSpec:
+    target_path: Path
+    arguments: str
+    working_directory: Path
+
+
+def is_autostart_supported() -> bool:
+    return os.name == "nt"
+
+
+def startup_shortcut_path(*, appdata: str | None = None) -> Path:
+    appdata_dir = appdata or os.environ.get("APPDATA")
+    if not appdata_dir:
+        raise AutostartError("APPDATA is not set; cannot find Windows Startup folder.")
+    return (
+        Path(appdata_dir)
+        / "Microsoft"
+        / "Windows"
+        / "Start Menu"
+        / "Programs"
+        / "Startup"
+        / _APP_SHORTCUT_NAME
+    )
+
+
+def runtime_shortcut_spec(
+    *, executable: str | os.PathLike[str] | None = None, frozen: bool | None = None
+) -> ShortcutSpec:
+    exe = Path(executable or sys.executable)
+    is_frozen = bool(getattr(sys, "frozen", False) if frozen is None else frozen)
+    if is_frozen:
+        return ShortcutSpec(target_path=exe, arguments="", working_directory=exe.parent)
+
+    # Source-tree fallback: useful for developers running Shaqcast without PyInstaller.
+    return ShortcutSpec(
+        target_path=exe,
+        arguments="-m shaqcast",
+        working_directory=Path.cwd(),
+    )
+
+
+def is_autostart_enabled(*, shortcut_path: Path | None = None) -> bool:
+    if not is_autostart_supported():
+        return False
+    path = shortcut_path or startup_shortcut_path()
+    return path.exists()
+
+
+def set_autostart_enabled(enabled: bool) -> None:
+    if not is_autostart_supported():
+        raise AutostartError("Autostart is only supported on Windows.")
+
+    shortcut_path = startup_shortcut_path()
+    if enabled:
+        _create_shortcut(shortcut_path, runtime_shortcut_spec())
+        return
+
+    try:
+        shortcut_path.unlink()
+    except FileNotFoundError:
+        return
+
+
+def _create_shortcut(shortcut_path: Path, spec: ShortcutSpec) -> None:
+    try:
+        import win32com.client  # type: ignore[import-not-found]
+
+        shell = win32com.client.Dispatch("WScript.Shell")
+    except Exception:
+        try:
+            import comtypes.client  # type: ignore[import-not-found]
+
+            shell = comtypes.client.CreateObject("WScript.Shell")
+        except Exception:
+            shell = None
+
+    shortcut_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if shell is None:
+        _create_shortcut_via_wsh(shortcut_path, spec)
+        return
+
+    shortcut = shell.CreateShortcut(str(shortcut_path))
+    shortcut.TargetPath = str(spec.target_path)
+    shortcut.Arguments = spec.arguments
+    shortcut.WorkingDirectory = str(spec.working_directory)
+    shortcut.Description = "Start Shaqcast at Windows logon"
+    shortcut.WindowStyle = 1
+    shortcut.Save()
+
+
+def _create_shortcut_via_wsh(shortcut_path: Path, spec: ShortcutSpec) -> None:
+    import subprocess
+    import tempfile
+
+    script = f"""
+Set shell = CreateObject("WScript.Shell")
+Set shortcut = shell.CreateShortcut("{_vbs_quote(shortcut_path)}")
+shortcut.TargetPath = "{_vbs_quote(spec.target_path)}"
+shortcut.Arguments = "{_vbs_quote(spec.arguments)}"
+shortcut.WorkingDirectory = "{_vbs_quote(spec.working_directory)}"
+shortcut.Description = "Start Shaqcast at Windows logon"
+shortcut.WindowStyle = 1
+shortcut.Save
+"""
+    with tempfile.NamedTemporaryFile("w", suffix=".vbs", delete=False, encoding="utf-8") as tmp:
+        tmp.write(script)
+        script_path = Path(tmp.name)
+
+    try:
+        result = subprocess.run(
+            ["cscript.exe", "//NoLogo", str(script_path)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        try:
+            script_path.unlink()
+        except OSError:
+            pass
+
+    if result.returncode != 0:
+        output = (result.stderr or result.stdout or "").strip()
+        raise AutostartError(output or "Failed to create Startup shortcut.")
+
+
+def _vbs_quote(value: str | os.PathLike[str]) -> str:
+    return str(value).replace('"', '""')

--- a/shaqcast/tests/test_startup.py
+++ b/shaqcast/tests/test_startup.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from shaqcast.startup import (
+    AutostartError,
+    runtime_shortcut_spec,
+    set_autostart_enabled,
+    startup_shortcut_path,
+)
+
+
+def test_startup_shortcut_path_uses_windows_startup_folder() -> None:
+    appdata = Path("C:/Users/user/AppData/Roaming")
+    path = startup_shortcut_path(appdata=str(appdata))
+
+    assert path == (
+        appdata
+        / "Microsoft"
+        / "Windows"
+        / "Start Menu"
+        / "Programs"
+        / "Startup"
+        / "Shaqcast.lnk"
+    )
+
+
+def test_runtime_shortcut_spec_for_frozen_exe() -> None:
+    exe = Path("C:/program portable/shaqcast.exe")
+    spec = runtime_shortcut_spec(executable=exe, frozen=True)
+
+    assert spec.target_path == exe
+    assert spec.arguments == ""
+    assert spec.working_directory == exe.parent
+
+
+def test_runtime_shortcut_spec_for_source_tree() -> None:
+    spec = runtime_shortcut_spec(executable="/usr/bin/python", frozen=False)
+
+    assert spec.target_path == Path("/usr/bin/python")
+    assert spec.arguments == "-m shaqcast"
+
+
+def test_set_autostart_enabled_rejects_non_windows() -> None:
+    if os.name == "nt":
+        pytest.skip("This test must not create a real Startup shortcut on Windows.")
+
+    with pytest.raises(AutostartError):
+        set_autostart_enabled(True)


### PR DESCRIPTION
## Co zmienia
- Dodaje w Shaqcast checkbox `Uruchamiaj Shaqcast z systemem` / `Start Shaqcast with Windows`.
- Włączenie opcji tworzy skrót `Shaqcast.lnk` w folderze Startup bieżącego użytkownika.
- Wyłączenie opcji usuwa ten skrót.
- Stan checkboxa jest synchronizowany z rzeczywistą obecnością skrótu na Windowsie i zapisywany w konfiguracji.

## Weryfikacja
- `python -m pytest -q tests` -> 19 passed, 1 skipped
- `python -m compileall -q shaqcast`
- `git diff --check`